### PR TITLE
change bosh2 to bosh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Current brews offered:
 - [safe](https://github.com/starkandwayne/safe)
 - [shield](https://github.com/starkandwayne/shield)
 - [yaml2json](https://github.com/bronze1man/go-yaml2json)
+- [bosh-cli](https://github.com/cloudfoundry/bosh-cli)
 
 ```
 $ brew install spruce

--- a/bosh.rb
+++ b/bosh.rb
@@ -1,6 +1,6 @@
 require "FileUtils"
 
-class Bosh2 < Formula
+class Bosh < Formula
   homepage "https://github.com/cloudfoundry/bosh-cli"
 
   v = "v3.0.1" # CI Managed
@@ -11,11 +11,11 @@ class Bosh2 < Formula
   sha256 "" # CI Managed
 
   def install
-    FileUtils.mv("bosh-cli-#{@@verNum}-darwin-amd64", "bosh2")
-    bin.install "bosh2"
+    FileUtils.mv("bosh-cli-#{@@verNum}-darwin-amd64", "bosh")
+    bin.install "bosh"
   end
 
   test do
-    system "#{bin}/bosh2", "--version"
+    system "#{bin}/bosh", "--version"
   end
 end

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -51,7 +51,7 @@ groups:
   - gotcha-debian
   - genesis-homebrew
   - genesis-debian
-  - bosh2-homebrew
+  - bosh-homebrew
   - bosh-cli-debian
   - bosh-init-homebrew
   - credhub-cli-debian
@@ -76,7 +76,7 @@ groups:
   - kafka-service-broker-homebrew
   - gotcha-homebrew
   - genesis-homebrew
-  - bosh2-homebrew
+  - bosh-homebrew
   - bosh-init-homebrew
 - name: debian
   jobs:
@@ -636,7 +636,7 @@ jobs:
           REPO_ROOT: homebrew
           REPO_OUT: pushme
           IN_BINARY: "bosh-cli-*-linux-amd64"
-          OUT_BINARY: bosh bosh2
+          OUT_BINARY: bosh
           NAME: bosh-cli
           LICENSE: Apache2
           DESCRIPTION: Interact with BOSH director
@@ -650,15 +650,15 @@ jobs:
           GPG_PUBLIC_KEY: (( grab meta.gpg.public_key ))
           GPG_PRIVATE_KEY: (( grab meta.gpg.private_key ))
 
-  - name: bosh2-homebrew
+  - name: bosh-homebrew
     public: true
     serial: true
     plan:
     - aggregate:
       - get: homebrew
         resource: homebrew
-      - get: bosh2
-        resource: bosh2
+      - get: bosh
+        resource: bosh
         trigger: true
     - task: update-homebrew
       config:
@@ -666,14 +666,14 @@ jobs:
         image_resource: (( grab meta.image ))
         inputs:
         - name: homebrew
-        - name: bosh2
+        - name: bosh
           path: recipe
         outputs:
         - name: pushme
         run:
           path: "homebrew/ci/scripts/update-homebrew.sh"
           args:
-          - bosh2.rb
+          - bosh.rb
         params:
           REPO_ROOT: homebrew
           REPO_OUT: pushme
@@ -1370,7 +1370,7 @@ resources:
     repository: kafka-service-broker
     access_token: (( grab meta.github.access_token ))
 
-- name: bosh2
+- name: bosh
   type: github-release
   source:
     user: cloudfoundry


### PR DESCRIPTION
Since bosh cli v3.0.1  is already out, it does not make sense to call it bosh2 anymore