### PR TITLE
Fix release versioning in download URI

### DIFF
--- a/pack.rb
+++ b/pack.rb
@@ -5,7 +5,7 @@ class Pack < Formula
 
   v = "v0.1.0" # CI Managed
   @@verNum = v.sub "v", ""
-  url "https://github.com/buildpack/pack/releases/download/#{v}/pack-#{@@verNum}-macos.tar.gz"
+  url "https://github.com/buildpack/pack/releases/download/#{v}/pack-#{v}-macos.tar.gz"
   version v
   sha256 "" # CI Managed
 


### PR DESCRIPTION
With the release of version 0.1.0, they have changed the download URI, I think. Now in both places the version is prefixed with "v", as you can see in the following example: https://github.com/buildpack/pack/releases/download/v0.1.0/pack-v0.1.0-macos.tgz
So I think '@@verNum = v.sub "v", ""' is not necessary any more.