### PR TITLE
Use `depends_on "openjdk"` instead of `java: "1.8"`

### DIFF
--- a/quaa.rb
+++ b/quaa.rb
@@ -12,7 +12,7 @@ class Quaa < Formula
   end
 
 
-  depends_on java: "1.8"
+  depends_on "openjdk"
   depends_on "cloudfoundry/tap/bosh-cli" => "5.2.2"
   depends_on "starkandwayne/cf/uaa-cli" => "0.0.1"
 


### PR DESCRIPTION
This allowed me to tap `starkandwayne/homebrew-cf`, but I didn't test if `quaa` can be installed and run with it.

Solves #22 